### PR TITLE
Configured spring error default trace value

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -26,7 +26,7 @@
 #   JAVA_HOME - location of a JDK home dir, required when download maven via java source
 #   MVNW_REPOURL - repo url base for downloading maven distribution
 #   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
-#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+#   MVNW_VERBOSE - true: enable verbose log; debug: traceInfo the mvnw script; others: silence the output
 # ----------------------------------------------------------------------------
 
 set -euf

--- a/src/main/java/com/hospital/mediflow/Common/Configuration/TraceParamFilter.java
+++ b/src/main/java/com/hospital/mediflow/Common/Configuration/TraceParamFilter.java
@@ -1,0 +1,30 @@
+package com.hospital.mediflow.Common.Configuration;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+public class TraceParamFilter extends OncePerRequestFilter {
+    @Value("${mediflow.detailed.exception}")
+    public boolean detailedException;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws java.io.IOException, jakarta.servlet.ServletException {
+
+        if (detailedException) {
+            request.setAttribute("trace",true);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/hospital/mediflow/Common/Exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/hospital/mediflow/Common/Exceptions/GlobalExceptionHandler.java
@@ -2,51 +2,99 @@ package com.hospital.mediflow.Common.Exceptions;
 
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.error.ErrorAttributeOptions;
+import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.jar.Attributes;
 
 @RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
 
+    private final DefaultErrorAttributes errorAttributes;
+
+    public GlobalExceptionHandler(DefaultErrorAttributes errorAttributes) {
+        this.errorAttributes = errorAttributes;
+    }
 
     @ExceptionHandler({BaseException.class})
-    public ResponseEntity<ErrorResponse> handleRecordAlreadyExistsException(BaseException exception){
+    public ResponseEntity<ErrorResponse> handleBaseException(WebRequest request,BaseException exception){
+        Map<String, Object> errorMap = getErrorAttributes(request);
+        errorMap.put("path",((ServletWebRequest) request).getRequest().getRequestURI());
+
         ErrorResponse response = ErrorResponse.builder()
                 .message(exception.getMessage())
+                .path(errorMap.getOrDefault("path","").toString())
+                .trace(errorMap.getOrDefault("trace","").toString())
                 .errorCode(exception.getErrorCode())
                 .occurredAt(exception.getTimestamp())
-                .trace(exception.getStackTrace())
                 .build();
 
         return new ResponseEntity<>(response,HttpStatus.valueOf(response.statusCode()));
     }
     @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<ErrorResponse> handleConstraintViolation(ConstraintViolationException ex) {
+    public ResponseEntity<ErrorResponse> handleConstraintViolation(WebRequest request,ConstraintViolationException exception) {
+        Map<String, Object> errorMap = getErrorAttributes(request);
+        errorMap.put("path",((ServletWebRequest) request).getRequest().getRequestURI());
         ErrorResponse response = ErrorResponse.builder()
-                .message(ex.getMessage())
-                .errorCode(ErrorCode.VALIDATION_ERROR)
+                .message("Constraint validation has failed")
+                .path(errorMap.getOrDefault("path","").toString())
+                .trace(errorMap.getOrDefault("trace","").toString())
                 .occurredAt(LocalDateTime.now())
+                .errorCode(ErrorCode.VALIDATION_ERROR)
                 .build();
 
         return ResponseEntity.badRequest().body(response);
     }
     @ExceptionHandler({MethodArgumentNotValidException.class})
-    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException exception){
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(WebRequest request,MethodArgumentNotValidException exception){
+        Map<String, Object> errorMap = getErrorAttributes(request);
+        errorMap.put("path",((ServletWebRequest) request).getRequest().getRequestURI());
+
         ErrorResponse response = ErrorResponse.builder()
-                .message(exception.getMessage())
-                .fieldErrors(exception.getFieldErrors())
+                .message("Argument validation has failed.")
+                .path(errorMap.getOrDefault("path","").toString())
+                .trace(errorMap.getOrDefault("trace","").toString())
+                .fieldErrorList(simplifyFieldErrors(exception.getFieldErrors()))
                 .occurredAt(LocalDateTime.now())
                 .errorCode(ErrorCode.METHOD_ARGUMENT_NOT_VALID)
-                .trace(exception.getStackTrace())
                 .build();
-        return new ResponseEntity<>(response, HttpStatus.valueOf(response.statusCode()));
+
+        return  ResponseEntity.status(HttpStatus.valueOf(response.statusCode())).body(response);
     }
 
+    private Map<String,Object> getErrorAttributes(WebRequest request){
+        Collection<ErrorAttributeOptions.Include> attributeList = new ArrayList<>();
+        if(Boolean.TRUE.equals(request.getAttribute("trace",WebRequest.SCOPE_REQUEST))){
+            attributeList.add(
+                    ErrorAttributeOptions.Include.STACK_TRACE
+            );
+        }
+        return errorAttributes.getErrorAttributes(request, ErrorAttributeOptions.of(attributeList));
 
+    }
+
+    private List<SimpleFieldError> simplifyFieldErrors(List<FieldError> fieldErrors){
+        return fieldErrors.stream()
+                .map(fe -> new SimpleFieldError(
+                        fe.getField(),
+                        fe.getRejectedValue().toString(),
+                        fe.getDefaultMessage()
+                ))
+                .toList();
+    }
 }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -14,5 +14,11 @@ logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 management.endpoints.web.exposure.include=health,info,metrics,env,beans,logfile,loggers
 management.endpoint.health.show-details=always
 
-#CUSTOM CONFIGURATIONS
+
+## Custom PROPERTIES
 mediflow.validate.phone = false
+mediflow.country.phone.prefix = +90
+mediflow.country.code=TR
+
+## Custom Detailed Exception PROPERTIES
+mediflow.detailed.exception = false

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -10,3 +10,10 @@ spring.jpa.properties.hibernate.format_sql=false
 
 management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.health.show-details=when_authorized
+
+mediflow.validate.phone = true
+mediflow.country.phone.prefix = +90
+mediflow.country.code=TR
+
+## Custom Detailed Exception PROPERTIES
+mediflow.detailed.exception = false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,10 +11,17 @@ spring.flyway.baseline-on-migrate=true
 spring.flyway.schemas=mediflow_schema
 spring.flyway.table=migrations
 
+## Base Controller Exception Behavior Properties
+server.error.include-stacktrace=on_param
+
+
 ## ACTUATORS
 management.endpoints.web.exposure.include=health,info,prometheus
 
-## Custom PROPERTIES
+## Custom Phone Validator PROPERTIES
 mediflow.validate.phone = true
 mediflow.country.phone.prefix = +90
 mediflow.country.code=TR
+
+## Custom Detailed Exception PROPERTIES
+mediflow.detailed.exception = false


### PR DESCRIPTION
I have configured Spring’s default error handling behavior and set server.error.include-stacktrace=on_param to make the stack trace optional.

Additionally, I created a class extending OncePerRequestFilter to use this property.

I also added a new property, mediflow.detailed.exception, which controls whether detailed exception information (including trace details) is included.

When this property is set to true, our TraceParamFilter adds a parameter to the request indicating that trace information should be included in the error response.

Finally, I implemented the getErrorAttributes method to decide dynamically whether to include the trace information in the response.


this commit is related to #10 