### PR TITLE
Updated enum operations

### DIFF
--- a/src/main/java/com/hospital/mediflow/Common/Exceptions/ErrorResponse.java
+++ b/src/main/java/com/hospital/mediflow/Common/Exceptions/ErrorResponse.java
@@ -1,10 +1,11 @@
 package com.hospital.mediflow.Common.Exceptions;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonIncludeProperties;
+
 import lombok.Builder;
-import org.springframework.validation.FieldError;
+
+
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -14,13 +15,22 @@ import java.util.List;
 public record ErrorResponse (
         String message,
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        List<FieldError> fieldErrors,
+        String path,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        List<SimpleFieldError> fieldErrorList,
         LocalDateTime occurredAt,
         ErrorCode errorCode,
-        StackTraceElement[] trace
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        String trace
 )
 {
-    public String statusCode(){
-        return errorCode().getStatusCode();
+    public int statusCode(){
+        return Integer.parseInt(errorCode.getStatusCode());
     }
 }
+
+record SimpleFieldError(
+        String field,
+        String rejectedValue,
+        String message
+) {}

--- a/src/main/java/com/hospital/mediflow/Common/Helpers/Annotations/EnumValidatorImpl.java
+++ b/src/main/java/com/hospital/mediflow/Common/Helpers/Annotations/EnumValidatorImpl.java
@@ -3,11 +3,15 @@ package com.hospital.mediflow.Common.Helpers.Annotations;
 import com.hospital.mediflow.Common.Annotations.ValidateEnum;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
 import java.util.List;
 
-public class EnumValidatorImpl implements ConstraintValidator<ValidateEnum,String> {
+@Slf4j
+@Component
+public class EnumValidatorImpl implements ConstraintValidator<ValidateEnum,Enum> {
     private List<String> enumValues;
     @Override
     public void initialize(ValidateEnum constraintAnnotation) {
@@ -17,7 +21,7 @@ public class EnumValidatorImpl implements ConstraintValidator<ValidateEnum,Strin
     }
 
     @Override
-    public boolean isValid(String value, ConstraintValidatorContext context) {
-        return value != null && enumValues.contains(value);
+    public boolean isValid(Enum value, ConstraintValidatorContext context) {
+        return value != null && enumValues.contains(value.name());
     }
 }

--- a/src/main/java/com/hospital/mediflow/Doctor/DataServices/Concretes/DoctorDataServiceImpl.java
+++ b/src/main/java/com/hospital/mediflow/Doctor/DataServices/Concretes/DoctorDataServiceImpl.java
@@ -36,7 +36,7 @@ public class DoctorDataServiceImpl implements DoctorDataService {
     public DoctorResponseDto save(DoctorRequestDto requestDto) {
         Doctor entity = mapper.toEntity(requestDto);
         if(repository.existsByDoctorCode(entity.getDoctorCode())){
-            String exceptionMessage = String.format("Doctor with %s doctor code is already exists. Please Change the specialty or title and try again.",
+            String exceptionMessage = String.format("Doctor with %d doctor code is already exists. Please Change the specialty or title and try again.",
                     requestDto.doctorCode());
             throw new RecordAlreadyExistException(exceptionMessage, ErrorCode.RECORD_ALREADY_EXISTS);
         }

--- a/src/main/java/com/hospital/mediflow/Doctor/Domain/Dtos/DoctorRequestDto.java
+++ b/src/main/java/com/hospital/mediflow/Doctor/Domain/Dtos/DoctorRequestDto.java
@@ -2,13 +2,16 @@ package com.hospital.mediflow.Doctor.Domain.Dtos;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.hospital.mediflow.Common.Annotations.ValidateEnum;
+import com.hospital.mediflow.Common.Annotations.ValidatePhone;
 import com.hospital.mediflow.Doctor.Enums.SpecialtyEnum;
 import com.hospital.mediflow.Doctor.Enums.TitleEnum;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import org.springframework.validation.annotation.Validated;
 
+@Validated
 public record DoctorRequestDto(
         @NotNull(message = "Title cannot be null")
         @ValidateEnum(enumClass = TitleEnum.class,message = "Invalid title value")
@@ -31,6 +34,7 @@ public record DoctorRequestDto(
 
         @NotBlank(message = "Phone cannot be empty")
         @Size(min = 10, max = 15, message = "Phone number must be between 10 and 15 characters")
+        @ValidatePhone(message = "Invalid phone format")
         String phone,
 
         @NotBlank(message = "Email cannot be empty")

--- a/src/main/java/com/hospital/mediflow/Doctor/Domain/Entities/Doctor.java
+++ b/src/main/java/com/hospital/mediflow/Doctor/Domain/Entities/Doctor.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
+import org.hibernate.annotations.Type;
 
 @Table(name = "doctors",schema = "mediflow_schema")
 @Entity

--- a/src/main/resources/migrations/V4__enum_type_change.sql
+++ b/src/main/resources/migrations/V4__enum_type_change.sql
@@ -1,0 +1,50 @@
+ALTER TABLE mediflow_schema.doctors DROP COLUMN specialty CASCADE;
+DROP TYPE IF EXISTS specialty_enum;
+
+ALTER TABLE mediflow_schema.doctors
+    ADD COLUMN specialty VARCHAR(50) NOT NULL DEFAULT 'N/A',
+    ADD CONSTRAINT specialty_check
+        CHECK (specialty IN ('CARDIOLOGY','DERMATOLOGY','HEMATOLOGY','NEUROLOGY','IMMUNOLOGY','INTERNAL_MEDICINE','EMERGENCY_MEDICINE','NEPHROLOGY','N/A'));
+
+ALTER TABLE mediflow_schema.doctors DROP COLUMN title CASCADE;
+DROP TYPE IF EXISTS title_enum;
+
+ALTER TABLE mediflow_schema.doctors
+    ADD COLUMN title VARCHAR(15) NOT NULL DEFAULT 'N/A',
+    ADD CONSTRAINT title_check
+        CHECK (title IN ('INTERN','ASSISTANT','SPECIALIST','PROFESSOR','N/A'));
+
+
+
+ALTER TABLE mediflow_schema.patients DROP COLUMN gender CASCADE;
+DROP TYPE IF EXISTS gender_enum;
+
+ALTER TABLE mediflow_schema.patients
+    ADD COLUMN gender VARCHAR(10) NOT NULL DEFAULT 'N/A',
+    ADD CONSTRAINT gender_check
+        CHECK (gender IN ('MALE','FEMALE','OTHER','N/A'));
+
+ALTER TABLE mediflow_schema.patients DROP COLUMN blood_group CASCADE;
+DROP TYPE IF EXISTS blood_group;
+
+ALTER TABLE mediflow_schema.patients
+    ADD COLUMN blood_group VARCHAR(5) NOT NULL DEFAULT 'N/A',
+    ADD CONSTRAINT blood_group_check
+        CHECK (blood_group IN ('00RH+','00RH-','A0RH+','A0RH-','B0RH+','B0RH-','ABRH+','ABRH-','N/A'));
+
+ALTER TABLE mediflow_schema.appointments DROP COLUMN status CASCADE;
+DROP TYPE IF EXISTS appointment_status_enum;
+
+ALTER TABLE mediflow_schema.appointments
+    ADD COLUMN status VARCHAR(15) NOT NULL DEFAULT 'N/A',
+    ADD CONSTRAINT appointment_status_check
+        CHECK (status IN ('PENDING','APPROVED','SCHEDULED','REJECTED','DONE','N/A'));
+
+ALTER TABLE mediflow_schema.billing DROP COLUMN status CASCADE;
+DROP TYPE IF EXISTS billing_status_enum;
+
+ALTER TABLE mediflow_schema.billing
+    ADD COLUMN status VARCHAR(15) NOT NULL DEFAULT 'N/A',
+    ADD CONSTRAINT billing_status_check
+        CHECK (status IN ('PENDING','APPROVED','TRANSFERRED','INVOICED','N/A'));
+


### PR DESCRIPTION
I have updated the enum operations that were causing the error.

I have solved 2 different issue in this commit. One of them was about Database <=> entity colum type mismatch.The  Database expected enum types for enum values while our application was trying to set enums as strings.

So I have created a new sql file and changed the column types as varchar. I have added constraint to use it like enum types.

The other issue was about Bean lifecycle and the usage of @ConditionalOnProperty . I have learned that when we use @ConditionalOnProperty for a bean, that bean is registered in the container at  bean definition time while @Value annotations are resolved at bean initialization time. this meant I couldn't receive the application.properties values from a bean that created with @ConditionalOnProperty annotation.

To fix this, I used the @Component annotation and injected the mediflow.validate.phone property to check whether the phone should be validated.

this commit is related to #7 